### PR TITLE
Agregado de mock de jest para redux y tests de pedido: listado y postulación

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 node_modules
 .env
 .vscode
+.idea
 coverage

--- a/src/__tests__/Login.test.js
+++ b/src/__tests__/Login.test.js
@@ -1,32 +1,60 @@
 import React from 'react';
 import faker from 'faker';
 import { render, fireEvent, waitFor } from '@testing-library/react';
+import { useSelector } from 'react-redux';
 import Login from 'Containers/Login';
-import store from 'Store/store';
-import { Provider } from 'react-redux';
-import { BrowserRouter, Router } from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+  useHistory: () => ({
+    push: jest.fn(),
+  }),
+}));
 
 describe('Register', () => {
-  test('Has email field', () => {
-    const { getByText } = render(<Provider store={store}><BrowserRouter><Router><Login /></Router></BrowserRouter></Provider>);
+  test('Has login button', () => {
+    useSelector.mockImplementation((selector) => selector({
+      logUser: {
+        data: { documentNumber: '232323' },
+        loggedIn: false,
+      },
+    }));
+    const { getByText } = render(<Router><Login /></Router>);
 
-    expect(getByText('Email')).toBeInTheDocument();
+    expect(getByText(/Login/i)).toBeInTheDocument();
   });
 
   test('Shows Required Error', () => {
-    const { getByText } = render(<Provider store={store}><BrowserRouter><Router><Login /></Router></BrowserRouter></Provider>);
+    useSelector.mockImplementation((selector) => selector({
+      logUser: {
+        data: { documentNumber: '232323' },
+        loggedIn: false,
+      },
+    }));
+
+    const { getByText } = render(<Router><Login /></Router>);
 
     fireEvent.change(document.getElementById('email'), { target: { value: 'esto no es email' } });
     fireEvent.change(document.getElementById('password'), { target: { value: 'password' } });
 
-    fireEvent.click(getByText(/Registrarse/i));
     fireEvent.click(getByText(/Login/i));
 
     expect(getByText(/Inserte un email válido/i)).toBeInTheDocument();
   });
 
   test('Submits form', async () => {
-    const dom = render(<Provider store={store}><BrowserRouter><Router><Login /></Router></BrowserRouter></Provider>);
+    useSelector.mockImplementation((selector) => selector({
+      logUser: {
+        data: {
+          documentNumber: '232323',
+        },
+        loggedIn: false,
+      },
+    }));
+
+    const dom = render(<Router><Login /></Router>);
 
     const user = {
       email: faker.internet.email(),
@@ -35,6 +63,7 @@ describe('Register', () => {
 
     fireEvent.change(document.getElementById('email'), { target: { value: user.email } });
     fireEvent.change(document.getElementById('password'), { target: { value: user.password } });
+    fireEvent.click(dom.getByText(/Login/i));
     await waitFor(() => {
       expect(dom.getByText(/Lo Sentimos! Ha ocurrido error./i)).toBeInTheDocument();
     });

--- a/src/__tests__/Login.test.js
+++ b/src/__tests__/Login.test.js
@@ -14,26 +14,22 @@ jest.mock('react-redux', () => ({
 }));
 
 describe('Register', () => {
-  test('Has login button', () => {
+  beforeEach(() => {
     useSelector.mockImplementation((selector) => selector({
       logUser: {
         data: { documentNumber: '232323' },
         loggedIn: false,
       },
     }));
+  });
+
+  test('Has login button', () => {
     const { getByText } = render(<Router><Login /></Router>);
 
     expect(getByText(/Login/i)).toBeInTheDocument();
   });
 
   test('Shows Required Error', () => {
-    useSelector.mockImplementation((selector) => selector({
-      logUser: {
-        data: { documentNumber: '232323' },
-        loggedIn: false,
-      },
-    }));
-
     const { getByText } = render(<Router><Login /></Router>);
 
     fireEvent.change(document.getElementById('email'), { target: { value: 'esto no es email' } });
@@ -45,15 +41,6 @@ describe('Register', () => {
   });
 
   test('Submits form', async () => {
-    useSelector.mockImplementation((selector) => selector({
-      logUser: {
-        data: {
-          documentNumber: '232323',
-        },
-        loggedIn: false,
-      },
-    }));
-
     const dom = render(<Router><Login /></Router>);
 
     const user = {

--- a/src/__tests__/Orders.test.js
+++ b/src/__tests__/Orders.test.js
@@ -1,11 +1,12 @@
 // eslint-disable jsx-props-no-spreading
 import React from 'react';
 import faker from 'faker';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { useSelector } from 'react-redux';
 import Orders from 'Components/OrdersList';
 import Order from 'Components/OrderCard';
 import ViewOrderModal from 'Components/Modals/ViewOrderModal';
+import SuccessModal from 'Components/Modals/SuccessModal';
 
 jest.mock('react-redux', () => ({
   useDispatch: jest.fn(),
@@ -112,9 +113,47 @@ describe('Orders', () => {
     expect(getByText(props.orders[0].description)).toBeInTheDocument();
   });
 
-  test('Apply for order', () => {
+  test('Shows more', () => {
+    const props = {
+      orders: [{
+        id: faker.random.number(),
+        description: faker.lorem.paragraph(),
+        title: faker.random.words(),
+        helpee: faker.internet.userName(),
+        categories: [{
+          label: 'Supermercado',
+        }],
+      }],
+    };
+    const setLoading = jest.fn();
+    const { getByText } = render(<Orders orders={props.orders} setLoading={setLoading} />);
+    fireEvent.click(getByText(/Ver más/i));
+    expect(getByText(/Descripción/i)).toBeInTheDocument();
+  });
+
+  test('Cancel view more', () => {
+    const props = {
+      orders: [{
+        id: faker.random.number(),
+        description: faker.lorem.paragraph(),
+        title: faker.random.words(),
+        helpee: faker.internet.userName(),
+        categories: [{
+          label: 'Supermercado',
+        }],
+      }],
+    };
+    const setLoading = jest.fn();
+    const { getByText, getAllByText } = render(<Orders orders={props.orders} setLoading={setLoading} />);
+    fireEvent.click(getByText(/Ver más/i));
+    fireEvent.click(getAllByText(/Cancelar/i)[1]);
+    expect(getAllByText(props.orders[0].description)[0]).toBeInTheDocument();
+  });
+
+  test('Take order modal', () => {
     const props = {
       order: {
+        id: faker.random.number(),
         description: faker.lorem.paragraph(),
         title: faker.random.words(),
         helpee: faker.internet.userName(),
@@ -125,11 +164,22 @@ describe('Orders', () => {
     };
     const onClose = jest.fn();
     const onConfirm = jest.fn();
-    const { getByText } = render(
+    const { getAllByText } = render(
       <ViewOrderModal order={props.order} onClose={onClose} onConfirm={onConfirm} />
     );
-    fireEvent.click(getByText(/Postularse/i));
+    fireEvent.click(getAllByText(/Postularse/i)[2]);
     expect(onConfirm).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  describe('Success modal for application', () => {
+    test('ok button', () => {
+      const setShow = jest.fn();
+      const { getByText } = render(
+        <SuccessModal message="Ha tomado la orden! Gracias por ayudar!" show setShow={setShow} />
+      );
+      fireEvent.click(getByText(/Ok/i));
+      expect(setShow).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/__tests__/Orders.test.js
+++ b/src/__tests__/Orders.test.js
@@ -1,10 +1,11 @@
 // eslint-disable jsx-props-no-spreading
 import React from 'react';
 import faker from 'faker';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { useSelector } from 'react-redux';
 import Orders from 'Components/OrdersList';
 import Order from 'Components/OrderCard';
+import ViewOrderModal from 'Components/Modals/ViewOrderModal';
 
 jest.mock('react-redux', () => ({
   useDispatch: jest.fn(),
@@ -23,6 +24,9 @@ describe('Orders', () => {
       },
     }));
   });
+  const openModal = jest.fn();
+  const viewportSize = jest.fn();
+
   test('Shows the title', () => {
     const props = {
       order: {
@@ -34,10 +38,7 @@ describe('Orders', () => {
         }],
       },
     };
-    const openModal = (order) => {
-      order.eq(props);
-    };
-    const { getByText } = render(<Order order={props.order} viewportSize={null} openModal={openModal} />);
+    const { getByText } = render(<Order order={props.order} viewportSize={viewportSize} openModal={openModal} />);
 
     expect(getByText(props.order.title)).toBeInTheDocument();
   });
@@ -56,10 +57,7 @@ describe('Orders', () => {
         }],
       },
     };
-    const openModal = (order) => {
-      order.eq(props);
-    };
-    const { getByText } = render(<Order order={props.order} viewportSize={null} openModal={openModal} />);
+    const { getByText } = render(<Order order={props.order} viewportSize={viewportSize} openModal={openModal} />);
 
     expect(getByText(`${props.order.helpee.name} ${props.order.helpee.lastname}`)).toBeInTheDocument();
   });
@@ -75,12 +73,25 @@ describe('Orders', () => {
         }],
       },
     };
-    const openModal = (order) => {
-      order.eq(props);
-    };
-    const { getByText } = render(<Order order={props.order} viewportSize={null} openModal={openModal} />);
+    const { getByText } = render(<Order order={props.order} viewportSize={viewportSize} openModal={openModal} />);
 
     expect(getByText(props.order.description)).toBeInTheDocument();
+  });
+
+  test('Open modal', () => {
+    const props = {
+      order: {
+        description: faker.lorem.paragraph(),
+        title: faker.random.words(),
+        helpee: faker.internet.userName(),
+        categories: [{
+          label: 'Supermercado',
+        }],
+      },
+    };
+    const { getByText } = render(<Order order={props.order} viewportSize="small" openModal={openModal} />);
+    fireEvent.click(getByText(/Ver más/i));
+    expect(openModal).toHaveBeenCalledTimes(1);
   });
 
   test('Shows orders', () => {
@@ -94,13 +105,31 @@ describe('Orders', () => {
           label: 'Supermercado',
         }],
       }],
-      loading: false,
     };
-    const setLoading = (newLoading) => {
-      props.loading = newLoading;
-    };
+    const setLoading = jest.fn();
     const { getByText } = render(<Orders orders={props.orders} setLoading={setLoading} />);
 
     expect(getByText(props.orders[0].description)).toBeInTheDocument();
+  });
+
+  test('Apply for order', () => {
+    const props = {
+      order: {
+        description: faker.lorem.paragraph(),
+        title: faker.random.words(),
+        helpee: faker.internet.userName(),
+        categories: [{
+          label: 'Supermercado',
+        }],
+      },
+    };
+    const onClose = jest.fn();
+    const onConfirm = jest.fn();
+    const { getByText } = render(
+      <ViewOrderModal order={props.order} onClose={onClose} onConfirm={onConfirm} />
+    );
+    fireEvent.click(getByText(/Postularse/i));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/__tests__/Orders.test.js
+++ b/src/__tests__/Orders.test.js
@@ -34,7 +34,10 @@ describe('Orders', () => {
         }],
       },
     };
-    const { getByText } = render(<Order {...props} />);
+    const openModal = (order) => {
+      order.eq(props);
+    };
+    const { getByText } = render(<Order order={props.order} viewportSize={null} openModal={openModal} />);
 
     expect(getByText(props.order.title)).toBeInTheDocument();
   });
@@ -53,7 +56,10 @@ describe('Orders', () => {
         }],
       },
     };
-    const { getByText } = render(<Order {...props} />);
+    const openModal = (order) => {
+      order.eq(props);
+    };
+    const { getByText } = render(<Order order={props.order} viewportSize={null} openModal={openModal} />);
 
     expect(getByText(`${props.order.helpee.name} ${props.order.helpee.lastname}`)).toBeInTheDocument();
   });
@@ -69,7 +75,10 @@ describe('Orders', () => {
         }],
       },
     };
-    const { getByText } = render(<Order {...props} />);
+    const openModal = (order) => {
+      order.eq(props);
+    };
+    const { getByText } = render(<Order order={props.order} viewportSize={null} openModal={openModal} />);
 
     expect(getByText(props.order.description)).toBeInTheDocument();
   });
@@ -85,8 +94,12 @@ describe('Orders', () => {
           label: 'Supermercado',
         }],
       }],
+      loading: false,
     };
-    const { getByText } = render(<Orders {...props} />);
+    const setLoading = (newLoading) => {
+      props.loading = newLoading;
+    };
+    const { getByText } = render(<Orders orders={props.orders} setLoading={setLoading} />);
 
     expect(getByText(props.orders[0].description)).toBeInTheDocument();
   });

--- a/src/__tests__/Orders.test.js
+++ b/src/__tests__/Orders.test.js
@@ -1,7 +1,7 @@
 // eslint-disable jsx-props-no-spreading
 import React from 'react';
 import faker from 'faker';
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { useSelector } from 'react-redux';
 import Orders from 'Components/OrdersList';
 import Order from 'Components/OrderCard';

--- a/src/__tests__/Orders.test.js
+++ b/src/__tests__/Orders.test.js
@@ -1,0 +1,93 @@
+// eslint-disable jsx-props-no-spreading
+import React from 'react';
+import faker from 'faker';
+import { render } from '@testing-library/react';
+import { useSelector } from 'react-redux';
+import Orders from 'Components/OrdersList';
+import Order from 'Components/OrderCard';
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+  useHistory: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+describe('Orders', () => {
+  beforeEach(() => {
+    useSelector.mockImplementation((selector) => selector({
+      logUser: {
+        data: { documentNumber: '232323' },
+        loggedIn: false,
+      },
+    }));
+  });
+  test('Shows the title', () => {
+    const props = {
+      order: {
+        description: faker.lorem.paragraph(),
+        title: faker.random.words(),
+        helpee: faker.internet.userName(),
+        categories: [{
+          label: 'Supermercado',
+        }],
+      },
+    };
+    const { getByText } = render(<Order {...props} />);
+
+    expect(getByText(props.order.title)).toBeInTheDocument();
+  });
+
+  test('Shows the helpee', () => {
+    const props = {
+      order: {
+        description: faker.lorem.paragraph(),
+        title: faker.random.words(),
+        helpee: {
+          name: faker.name.firstName(),
+          lastname: faker.name.lastName(),
+        },
+        categories: [{
+          label: 'Supermercado',
+        }],
+      },
+    };
+    const { getByText } = render(<Order {...props} />);
+
+    expect(getByText(`${props.order.helpee.name} ${props.order.helpee.lastname}`)).toBeInTheDocument();
+  });
+
+  test('Shows the description', () => {
+    const props = {
+      order: {
+        description: faker.lorem.paragraph(),
+        title: faker.random.words(),
+        helpee: faker.internet.userName(),
+        categories: [{
+          label: 'Supermercado',
+        }],
+      },
+    };
+    const { getByText } = render(<Order {...props} />);
+
+    expect(getByText(props.order.description)).toBeInTheDocument();
+  });
+
+  test('Shows orders', () => {
+    const props = {
+      orders: [{
+        id: faker.random.number(),
+        description: faker.lorem.paragraph(),
+        title: faker.random.words(),
+        helpee: faker.internet.userName(),
+        categories: [{
+          label: 'Supermercado',
+        }],
+      }],
+    };
+    const { getByText } = render(<Orders {...props} />);
+
+    expect(getByText(props.orders[0].description)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/Register.test.js
+++ b/src/__tests__/Register.test.js
@@ -1,13 +1,36 @@
 import React from 'react';
 import faker from 'faker';
 import { render, fireEvent, waitFor } from '@testing-library/react';
+import { useSelector } from 'react-redux';
 import Register from 'Containers/Register';
 
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+  useHistory: () => ({
+    push: jest.fn(),
+  }),
+}));
+
 describe('Register', () => {
+  beforeEach(() => {
+    useSelector.mockImplementation((selector) => selector({
+      logUser: {
+        data: { documentNumber: '232323' },
+        loggedIn: false,
+      },
+    }));
+  });
   test('Has email field', () => {
     const { getByText } = render(<Register />);
 
     expect(getByText('Email')).toBeInTheDocument();
+  });
+
+  test('Has profile pic', () => {
+    const { getByText } = render(<Register />);
+
+    expect(getByText('Sube tu foto de perfil')).toBeInTheDocument();
   });
 
   test('Shows Required Error', () => {
@@ -59,5 +82,11 @@ describe('Register', () => {
     expect(getByText(/Número de documento/i)).toBeInTheDocument();
     expect(getByText(/Frente del Documento/i)).toBeInTheDocument();
     expect(getByText(/Dorso del Documento/i)).toBeInTheDocument();
+  });
+
+  test('Volunteer Document', () => {
+    const { getByText } = render(<Register volunteer />);
+
+    expect(getByText(/Frente del Documento/i)).toBeInTheDocument();
   });
 });

--- a/src/components/Modals/ViewOrderModal/index.jsx
+++ b/src/components/Modals/ViewOrderModal/index.jsx
@@ -15,7 +15,7 @@ const ViewOrderModal = ({ order, onClose, onConfirm }) => (
       <UserProfileInfo user={order.helpee} />
       <Box>
         <Heading level="4" margin="none">
-          Categorias
+          Categorías
         </Heading>
         <ChipContainer items={order.categories} label="description" />
       </Box>
@@ -31,7 +31,7 @@ const ViewOrderModal = ({ order, onClose, onConfirm }) => (
         <Button secondary label="Cancelar" onClick={onClose} />
         <Button
           primary
-          label="Tomar Pedido"
+          label="Postularse"
           onClick={() => {
             onConfirm(order.id);
             onClose();

--- a/src/components/OrderCard/index.jsx
+++ b/src/components/OrderCard/index.jsx
@@ -26,7 +26,7 @@ const OrderCard = ({ order, viewportSize, openModal }) => (
       <Button
         primary
         size={viewportSize === 'small' ? 'small' : 'medium'}
-        label="Ver Mas"
+        label="Ver más"
         onClick={() => openModal(order)}
       />
     </CardFooter>

--- a/src/components/OrdersList/index.jsx
+++ b/src/components/OrdersList/index.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useContext } from 'react';
-import './index.scss';
 import { Box, ResponsiveContext } from 'grommet';
 import PropTypes from 'prop-types';
 import ordersService from 'Api/orders.service';

--- a/src/components/OrdersList/index.jsx
+++ b/src/components/OrdersList/index.jsx
@@ -45,7 +45,7 @@ const OrdersList = ({ orders, setLoading }) => {
 
   return (
     <Box
-      background="white"
+      background-color="white"
       direction="column"
       pad={{ horizontal: viewportSize === 'small' ? 'small' : '20vw', vertical: 'medium' }}
       overflow="scroll"

--- a/src/components/OrdersList/index.jsx
+++ b/src/components/OrdersList/index.jsx
@@ -45,7 +45,7 @@ const OrdersList = ({ orders, setLoading }) => {
 
   return (
     <Box
-      background-color="white"
+      background="white"
       direction="column"
       pad={{ horizontal: viewportSize === 'small' ? 'small' : '20vw', vertical: 'medium' }}
       overflow="scroll"

--- a/src/containers/Login/index.jsx
+++ b/src/containers/Login/index.jsx
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
 import React, { useState, useEffect } from 'react';
-import { Box, Button, Grid, Heading, TextInput, Text, FormField, Form } from 'grommet';
+import {
+  Box, Button, Grid, Heading, TextInput, Text, FormField, Form,
+} from 'grommet';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import usersService from 'Api/users.service';

--- a/src/containers/Orders/index.jsx
+++ b/src/containers/Orders/index.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import './index.scss';
 import { Box, Heading } from 'grommet';
 import ordersService from 'Api/orders.service';
 import OrdersList from 'Components/OrdersList';

--- a/src/containers/Register/index.jsx
+++ b/src/containers/Register/index.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Box, Grid, Button, Heading, Avatar, Form, Text } from 'grommet';
+import {
+  Box, Grid, Button, Heading, Avatar, Form, Text,
+} from 'grommet';
 import { useHistory } from 'react-router-dom';
 import volunteerService from 'Api/volunteer.service';
 import helpeeService from 'Api/helpee.service';


### PR DESCRIPTION
Se agregó el mock de jest para redux y se realizaron nuevos chequeos de campos obligatorios en login y signup.
Se agregaron  tests correspondientes a los pedidos (Order):
- chequeos de campos necesarios
- muestra de listado de pedidos
- evento de apertura de modal de pedido
- evento de "Postularse" a pedido
- evento de cancelar "Postularse" a pedido
- modal de éxito

Además, se cambiaron algunos textos para que tengan solo la primer letra de la frase en mayúscula y tildes.