### PR TITLE
Solved issues with list orders in map

### DIFF
--- a/src/components/MapOrderList/index.jsx
+++ b/src/components/MapOrderList/index.jsx
@@ -1,5 +1,7 @@
 /* eslint-disable react/no-array-index-key */
-import React, { useRef, useState, useEffect } from 'react';
+import React, {
+  useRef, useState, useEffect,
+} from 'react';
 import { compose, withProps } from 'recompose';
 import {
   withScriptjs,
@@ -10,6 +12,7 @@ import {
 } from 'react-google-maps';
 import { Box } from 'grommet';
 import orderServices from 'Api/orders.service';
+import { useSelector } from 'react-redux';
 
 const MapOrderList = compose(
   withProps({
@@ -30,6 +33,7 @@ const MapOrderList = compose(
   const [markers, setMarkers] = useState([]);
   const [firstLoad, setFirstLoad] = useState(true);
   const mapZoom = 13;
+  const userData = useSelector((state) => state.logUser.data);
 
   useEffect(() => {
     setCircles(
@@ -89,7 +93,7 @@ const MapOrderList = compose(
       onZoomChanged={getOrders}
       onTilesLoaded={getOrdersFirstTime}
       defaultZoom={mapZoom}
-      defaultCenter={{ lat: -34.910241, lng: -56.176663 }}
+      defaultCenter={{ lat: userData.latitude, lng: userData.longitude }}
     >
       {circles}
       {markers}

--- a/src/components/OrdersList/index.jsx
+++ b/src/components/OrdersList/index.jsx
@@ -15,7 +15,7 @@ import MapOrderList from 'Components/MapOrderList';
 import { List, Map } from 'grommet-icons';
 
 const OrdersList = ({
-  orders, setLoading, modalClosed,
+  orders, setLoading, modalClosed, isMyOrders,
 }) => {
   const takeOrder = async (orderId) => {
     try {
@@ -111,12 +111,12 @@ const OrdersList = ({
   return (
     <Box fill={isMapEnabled} overflow="auto" flex={false}>
 
-      {isVolunteer && (
+      {isVolunteer && !isMyOrders && (
         <Box
           direction="row"
           alignSelf="end"
           background="white"
-          border="black"
+          style={{ border: '1px solid grey' }}
           margin={{ top: 'medium', right: 'medium', bottom: 'xsmall' }}
         >
           <Button
@@ -160,10 +160,15 @@ const OrdersList = ({
   );
 };
 
+OrdersList.defaultProps = {
+  isMyOrders: false,
+};
+
 OrdersList.propTypes = {
   orders: PropTypes.array.isRequired,
   setLoading: PropTypes.func.isRequired,
   modalClosed: PropTypes.func.isRequired,
+  isMyOrders: PropTypes.bool,
 };
 
 export default OrdersList;

--- a/src/containers/MyOrders/index.jsx
+++ b/src/containers/MyOrders/index.jsx
@@ -47,17 +47,17 @@ const MyOrders = () => {
     <Box fill align="center">
       {loading && <Spinner />}
       {!userInfo.documentNumber
-      && (
-        <Button
-          alignSelf="end"
-          disabled={loading}
-          primary
-          icon={<Add color="white" />}
-          onClick={() => setCreateOrderModal(true)}
-          label="Nuevo pedido"
-          margin={{ right: 'xlarge', vertical: 'small' }}
-        />
-      )}
+        && (
+          <Button
+            alignSelf="end"
+            disabled={loading}
+            primary
+            icon={<Add color="white" />}
+            onClick={() => setCreateOrderModal(true)}
+            label="Nuevo pedido"
+            margin={{ right: 'xlarge', vertical: 'small' }}
+          />
+        )}
       {createOrderModal && <CreateOrder closeModal={closeModal} />}
       {orders.length === 0 && !loading && (
         <Heading level="2" textAlign="center">
@@ -67,7 +67,7 @@ const MyOrders = () => {
             && 'Usted no ha cargado ningún pedido aún'}
         </Heading>
       )}
-      {orders.length > 0 && <OrdersList orders={orders} setLoading={setLoading} modalClosed={setViewOrderModal} />}
+      {orders.length > 0 && <OrdersList orders={orders} setLoading={setLoading} modalClosed={setViewOrderModal} isMyOrders />}
     </Box>
   );
 };


### PR DESCRIPTION
Solved issue: [Ver pedidos sin tomar utilizando un mapa] No se centra el viewport en la ubicación del voluntario
Fixed: in Mis pedidos now the options menu for switch between the list view and the map view are delete